### PR TITLE
Add tabindex option

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -338,7 +338,8 @@ jQuery.trumbowyg = {
                 .addClass(prefix + 'editor')
                 .attr({
                     'contenteditable': true,
-                    'dir': t.lang._dir || t.o.dir
+                    'dir': t.lang._dir || t.o.dir,
+                    'tabindex': t.tabindex || -1
                 })
                 .html(html)
             ;


### PR DESCRIPTION
expose "tabindex" option for trumbowyg editor so the editor area can be focused with the tab key
